### PR TITLE
Proposition pour le rendu plasTeX -> HTML

### DIFF
--- a/generator/songs.py
+++ b/generator/songs.py
@@ -98,7 +98,6 @@ class Renderer:
 
 
 def parse_song(filename):
-    filename = '/home/louis/projets/songbook/core/songbook_core/data/examples/songs/vent_frais.sg'
     tex = SongParser.parse(filename)
     return Renderer(tex).renderNodes(tex.childNodes)
 

--- a/generator/songs.py
+++ b/generator/songs.py
@@ -71,30 +71,16 @@ class Renderer:
         return ""
 
     def renderChord(self, node):
-        # Je ne comprend pas pourquoi la version suivante, bien plus élégante,
-        # m'introduit des saut de ligne partout...
-        # return u"""<span class="chord">
-        #         <span class="chord-name">
-        #         {}
-        #         </span><span class="chord-text">
-        #         {}
-        #         </span>
-        #         </span>""".format(
-        #                 node.chord.replace('&', u"♭").replace('#', u"♯"),
-        #                 "", # TODO
-        #                 )
-        return (
-                u'<span class="chord">'
-                u'<span class="chord-name">'
-                u'{}'
-                u'</span><span class="chord-text">'
-                u'{}'
-                u'</span>'
-                u'</span>'
-                ).format(
-                        node.chord.replace('&', u"♭").replace('#', u"♯"),
-                        "", # TODO
-                        )
+         return u"""<span class="chord">
+                 <span class="chord-name">
+                 {}
+                 </span><span class="chord-text">
+                 {}
+                 </span>
+                 </span>""".format(
+                         node.chord.replace('&', u"♭").replace('#', u"♯"),
+                         "", # TODO
+                         )
 
 
 def parse_song(filename):

--- a/generator/templates/generator/show_song.html
+++ b/generator/templates/generator/show_song.html
@@ -34,7 +34,7 @@
 	{% endif %}
 	</p>
 	{% endcomment %}
-	<div class="song_content">{{ content|safe|linebreaks }}</div>
+	<div class="song_content">{{ content|safe }}</div>
 
 {% endblock %}
 


### PR DESCRIPTION
J'ai essayé d'utiliser les renderers plasTeX, mais je me suis rendu compte qu'effectivement, si on ne veut pas écrire dans un fichier, c'est compliqué. Par contre, j'ai repris le principe.

Le renderer a un dictionnaire dont les clefs sont les noms des nœuds, et les valeurs sont la fonction à appeler pour rendre ce nœud là. Il y a en plus une fonction `renderDefault` pour rendre un nœud non présent dans le dictionnaire.

Ça fonctionne pas mal, le seul problème étant que le document HTML final a plein de `<br>` introduits n'importe où, qui font des sauts de lignes disgracieux ([exemple](https://github.com/patacrep/songbook-web/blob/fa9d15c76d17a0d895f8c6b217770a5a4c8c432a/generator/songs.py#L74-85)). Je ne sais pas si un post-traitement est appliqué aux chaînes pour remplacer tous les sauts de lignes par des `<br>`.

Pour compléter cela, on peut : 
- compléter toutes les fonction `render*()` pour les nœuds qui nous intéressent (les commandes spéciales de songs s'il en reste, les commandes classiques de typographie : italique, gras, etc. quelques caractères spéciaux, etc.
- voir si on peu prendre des choses de la [fonction par défaut](http://plastex.sourceforge.net/plastex/sect0011.html) proposée par plasTeX.
- supprimer les TODO.
