### PR TITLE
Reduce number of SQL request

### DIFF
--- a/generator/models.py
+++ b/generator/models.py
@@ -97,7 +97,9 @@ class Songbook(models.Model):
         return count
 
     def count_artists(self):
-        songs = ItemsInSongbook.objects.filter(
+        songs = ItemsInSongbook.objects.prefetch_related(
+                   'item'
+                   ).filter(
                    songbook=self,
                    item_type=ContentType.objects.get_for_model(Song)
                    )

--- a/generator/models.py
+++ b/generator/models.py
@@ -105,7 +105,7 @@ class Songbook(models.Model):
                    )
         artists = set()
         for song in songs:
-            artists.add(song.item.artist.id)
+            artists.add(song.item.artist_id)
         return len(artists)
 
     def count_section(self):

--- a/generator/views/songbooks.py
+++ b/generator/views/songbooks.py
@@ -83,7 +83,9 @@ class ShowSongbook(OwnerOrPublicRequiredMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super(ShowSongbook, self).get_context_data(**kwargs)
-        items_list = ItemsInSongbook.objects.filter(songbook=self.object)
+        items_list = ItemsInSongbook.objects.prefetch_related(
+                   'item', 'item_type'
+                   ).filter(songbook=self.object)
         context['items_list'] = items_list
         if self.request.user == self.object.user:
             context['can_edit'] = True


### PR DESCRIPTION
Je pense qu'il y a quelques astuces simples qui permettraient d'économiser pas mal de requêtes SQL (avec une 40aine de chants, il y a plus de 100 requêtes...)

J'en notamment utilisé 'prefetch_related':
266db5d, eb7e062
