### PR TITLE
Propagate error messages

### DIFF
--- a/generator/build.py
+++ b/generator/build.py
@@ -68,7 +68,7 @@ def generate_songbook(songbook, layout):
     for step in ["tex", "pdf", "sbx", "pdf", "clean"]:
         try:
             builder.build_steps([step])
-        except SongbookError:
-            raise GeneratorError("Error during the step '{0}'".format(step))
+        except SongbookError as e:
+            raise GeneratorError("Error during the step '{0}': {1}".format(step, e))
 
     return tmpfile + ".pdf"

--- a/generator/tasks.py
+++ b/generator/tasks.py
@@ -33,11 +33,11 @@ def queue_render_task(task_id):
 
     try:
         filename = generate_songbook(task.songbook, task.layout)
-    except GeneratorError:
+    except GeneratorError as e:
         task.state = GeneratorTask.State.ERROR
         task.save()
-        LOGGER.error("Failed task {0} (state : {1})"\
-                      .format(task.id, task.state))
+        LOGGER.error("Failed task {0} (state : {1}): {2}"\
+                      .format(task.id, task.state, e))
 
         return
 

--- a/generator/tasks.py
+++ b/generator/tasks.py
@@ -35,6 +35,7 @@ def queue_render_task(task_id):
         filename = generate_songbook(task.songbook, task.layout)
     except GeneratorError as e:
         task.state = GeneratorTask.State.ERROR
+        task.result = {"error_msg": str(e)}
         task.save()
         LOGGER.error("Failed task {0} (state : {1}): {2}"\
                       .format(task.id, task.state, e))


### PR DESCRIPTION
J'ai eu du mal à debugger il y a quelques temps parce que les messages d'erreur étaient trop lacunaires: `Failed Task 17 (state: ERROR)` par exemple.

Du coup j'ai propose des modif pour que les textes de certaines erreur "parentes" soient propagées.

Ces messages ne sont pas destinés à être affichés à l'utilisateur final (seulement aux dev)
