### PR TITLE
Import songs reflects the last patacrep changes

### DIFF
--- a/generator/management/commands/cleancatalog.py
+++ b/generator/management/commands/cleancatalog.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#    Copyright (C) 2015 The Patacrep Team
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from django.core.management.base import BaseCommand
+
+from generator.models import Artist, Songbook
+
+class Command(BaseCommand):
+    args = ""
+    help = "Remove all songs, artists and songbooks from the db"
+
+    def handle(self, *args, **options):
+        Artist.objects.all().delete()
+        Songbook.objects.all().delete()

--- a/generator/management/songs.py
+++ b/generator/management/songs.py
@@ -18,6 +18,7 @@ Songs management utilities
 """
 from django.conf.global_settings import LANGUAGES
 from django.utils.text import slugify
+from django.db import transaction
 
 from generator.models import Song, Artist
 from patacrep.latex import parse_song
@@ -26,78 +27,111 @@ import pygit2 as git
 import pprint
 import os
 import logging
+from functools import lru_cache
+import time
+
 LOGGER = logging.getLogger(__name__)
 
-def import_song(filepath, song_directory):
-    '''Import a song in the database'''
-    with open(filepath) as song:
-        #TODO: PROBABLY BROKEN
-        data = parse_song(song.read(), filepath)
-    LOGGER.info("Processing " +
-                pprint.pformat(data['@titles'][0]))
+@transaction.atomic
+def import_songs(metadata):
+    """Import all the metadata into the database"""
+    catalog = Catalog()
+    songs = []
+    for song in metadata:
+        title = song['titles'][0]
 
-    artist_name = data['by']
-    artist_slug = slugify(artist_name)
+        if song['filepath'] in catalog.filepaths:
+            LOGGER.info(
+                "Skip: "
+                + title
+                + "\t\t\t\t\t- Already in Database")
+            continue
 
-    artist_model, created = Artist.objects.get_or_create(
+        object_hash = git.hashfile(song['fullpath'])
+        artist_id = catalog.get_artist_id(song['authors'][0])
+        song_slug = catalog.get_song_slug(title)
+        data = {
+            'artist_id' :    artist_id,
+            'title'     :    title,
+            'language'  :    song['lang'],
+            'slug'      :    song_slug,
+            'file_path' :    song['filepath'],
+            'object_hash':   object_hash,
+        }
+
+        LOGGER.info("Adding: " + title)
+        model = Song(**data)
+        songs.append(model)
+
+    Song.objects.bulk_create(songs)
+    LOGGER.info(
+        " -> " +
+        str(len(songs)) + 
+        " songs added to the db")
+
+class Catalog:
+    """Class used to efficiently compute slugs and prevent database collision"""
+    def __init__(self):
+        self._init_songs()
+        self._init_artists()
+
+    def _init_songs(self):
+        songs = Song.objects.values_list('file_path', 'slug')
+        if not songs:
+            self.filepaths = set()
+            self.song_slugs = set()
+        else:
+            self.filepaths, self.song_slugs = map(set, zip(*songs))
+
+    def get_song_slug(self, title):
+        slug = slugify(title)
+        if slug in self.song_slugs:
+            i = 1
+            tmp_slug = slug + '-' + str(i)
+            while tmp_slug in self.song_slugs:
+                i += 1
+                tmp_slug = slug + '-' + str(i)
+
+            LOGGER.info(
+                "Slug collision: "
+                + slug + ". Use "
+                + tmp_slug + " instead for "
+                + title)
+            slug = tmp_slug
+
+        self.song_slugs.add(slug)
+        return slug
+
+    def _init_artists(self):
+        artists = Artist.objects.values_list('id', 'slug', 'name')
+        self.artists = {slug: (id, name) for id, slug, name in artists}
+
+    def get_artist_name(self, name_tuple):
+        last_name, first_name = name_tuple
+        if first_name:
+            artist_name = first_name + ' ' + last_name
+        else:
+            artist_name = last_name
+
+        return artist_name
+
+    def get_artist_id(self, name_tuple):
+        artist_name = self.get_artist_name(name_tuple)
+        artist_slug = slugify(artist_name)
+
+        try:
+            id, name = self.artists[artist_slug]
+            if (name != artist_name):
+                LOGGER.warning(
+                    "*** Artist name differs though "
+                    "slugs are equal : "
+                    + artist_name + " / "
+                    + name)
+            return id
+        except KeyError:
+            model = Artist.objects.create(
                             slug=artist_slug,
-                            defaults={'name': artist_name}
+                            name=artist_name,
                             )
-    if not created:
-        if (artist_model.name != artist_name):
-            LOGGER.warning(
-                "*** Artist name differs though "
-                "slugs are equal : "
-                + artist_name + " / "
-                + artist_model.name)
-
-    if (len(data['@languages']) > 1):
-        LOGGER.warning("*** Multiple languages "
-                        "in song file; we though"
-                        " only support one. "
-                        "Picking any.")
-    if (len(data['@languages']) > 0):
-        language_name = data["@languages"].pop()
-        language_code = next(
-                    (x for x in LANGUAGES
-                     if x[1].lower() == language_name.lower()
-                     ),
-                    ('', '')
-                     )[0]
-        if language_code == '':
-            LOGGER.warning("*** No code found for "
-                    "language : '" + language_name + "'")
-
-    song_title = data['@titles'][0]
-    song_slug = slugify(song_title)
-
-    object_hash = git.hashfile(filepath)
-    filepath_rel = os.path.relpath(filepath, song_directory)
-
-    import random
-
-    # For some reason - probably after having interrupted
-    # the generation - insertion fails because slug is
-    # empty, and there is already an empty one.
-    # We assign here a random value, that gets overwritten
-    # afterwards.
-    song_model, created = Song.objects.get_or_create(
-                            title=song_title,
-                            artist=artist_model,
-                            defaults={
-                                'title': song_title,
-                                'language': language_code,
-                                'file_path': filepath_rel,
-                                'slug': ('%06x' % random.randrange(16**6))
-                            })
-    if created:
-        if Song.objects.filter(slug=song_slug).exists():
-            song_slug += '-' + str(song_model.id)
-        song_model.slug = song_slug
-
-    else:
-        LOGGER.info("-> Already exists.")
-
-    artist_model.save()
-    song_model.object_hash = object_hash
-    song_model.save()
+            self.artists[artist_slug] = model.id, artist_name
+            return model.id

--- a/generator/management/songs.py
+++ b/generator/management/songs.py
@@ -16,19 +16,13 @@
 """
 Songs management utilities
 """
-from django.conf.global_settings import LANGUAGES
 from django.utils.text import slugify
 from django.db import transaction
 
 from generator.models import Song, Artist
-from patacrep.latex import parse_song
 
 import pygit2 as git
-import pprint
-import os
 import logging
-from functools import lru_cache
-import time
 
 LOGGER = logging.getLogger(__name__)
 

--- a/generator/patacrep.py
+++ b/generator/patacrep.py
@@ -38,20 +38,31 @@ def build_songbook(content, outputfile, steps):
             from generator.build import GeneratorError
             raise GeneratorError("Error during the step '{0}': {1}".format(step, e))
 
+def extract_metadata(filepath, datadir):
+    song = HtmlSong(filepath, datadir)
+    metadata = {
+        'authors': song.authors,
+        'titles':  song.titles,
+        'lang':  song.lang,
+        'filepath':  filepath,
+        'datadir':  datadir,
+        'fullpath':  song.fullpath,
+    }
+    return metadata
 
 class HtmlSong(Chordpro2HtmlSong):
 
-    def __init__(self, filename):
-        # TODO: Clean this hack
-        # Hack to read the .sgc file
-        filename += "c"
+    def __init__(self, filename, datadir=None):
+        filename = os.path.join('songs', filename)
 
-        relpath = os.path.join('songs', filename)
-
-        datadir = os.path.abspath(settings.SONGS_LIBRARY_DIR)
+        if not datadir:
+            datadir = os.path.abspath(settings.SONGS_LIBRARY_DIR)
         config = DEFAULT_CONFIG.copy()
         config['datadir'].append(datadir)
-        super().__init__(relpath, config, datadir=datadir)
+
+        # without the encoding, the reading fails
+        config['encoding'] = 'utf-8'
+        super().__init__(filename, config, datadir=datadir)
 
         self.more = {
             'failed': (self.titles == []),


### PR DESCRIPTION
J'ai fait une grosse mise à jour de la commande `importsongs` pour notamment refléter les derniers changements de patacrep.

J'en ai profité pour diminuer les accès à la base de donnée (pour 900 chants, cela prend quelques secondes).
En revanche le premier parsage des chants par patacrep peut prendre un peu de temps (heureusement une mise en cache est effectuée pour les accès ultérieurs).

J'apprécierai que quelqu'un y jette un oeil avant de merger (ping @Luthaf)
